### PR TITLE
Make a runnable example with explanation

### DIFF
--- a/src/KNPEMI/KNPEMIx_solver.py
+++ b/src/KNPEMI/KNPEMIx_solver.py
@@ -456,7 +456,7 @@ class SolverKNPEMI(object):
         facets_gamma = p.boundaries.indices[gamma_indices]
         dofs_gamma   = dfx.fem.locate_dofs_topological(phi_M_space, p.mesh.topology.dim-1, facets_gamma)
         self.point_to_plot = dofs_gamma[0]
-
+    
 
         self.v_t = []
         self.v_t.append(1000 * p.phi_M_prev.x.array[self.point_to_plot]) # Converted to mV

--- a/src/KNPEMI/KNPEMIx_solver.py
+++ b/src/KNPEMI/KNPEMIx_solver.py
@@ -456,7 +456,6 @@ class SolverKNPEMI(object):
         facets_gamma = p.boundaries.indices[gamma_indices]
         dofs_gamma   = dfx.fem.locate_dofs_topological(phi_M_space, p.mesh.topology.dim-1, facets_gamma)
         self.point_to_plot = dofs_gamma[0]
-    
 
         self.v_t = []
         self.v_t.append(1000 * p.phi_M_prev.x.array[self.point_to_plot]) # Converted to mV

--- a/src/KNPEMI/generate_square_mesh.py
+++ b/src/KNPEMI/generate_square_mesh.py
@@ -1,17 +1,25 @@
-import sys
-
+import argparse
+from pathlib import Path
+from mpi4py import MPI
 import dolfinx as dfx
 
 from utils_dfx import mark_subdomains_square, mark_boundaries_square
-from mpi4py import MPI
-
-flag = 'w' # Read or write
-
-# Set mesh parameters and filename
-N = int(sys.argv[1])
+from parsers import CustomParser
+description = """
+Create a unit square mesh where a sub-square [0.25,0.25]x[0.75,0.75] is tagged as subdomain 1 and the rest as subdomain 2.
+The exterior boundary as tagged as 3, the interface between the domains with 4 and all other facets with 5.
+"""
+parser = argparse.ArgumentParser(formatter_class=CustomParser,
+                                 description=description)
+parser.add_argument("-N", "--N" ,default=20, type=int, help="Number of elements in each direction")
+parser.add_argument("-f", "--flag", dest="flag", default='w', type=str, choices=["r", "w"], help="Read or write")
+parser.add_argument("-o", "--output", dest="output_dir", default='./geometries', type=Path, help="Output directory")
+args = parser.parse_args()
+flag = args.flag
+N = args.N
 gm = dfx.mesh.GhostMode.shared_facet
 comm = MPI.COMM_WORLD
-filename = './geometries/square' + str(N) + '.xdmf'
+filename = args.output_dir / f"square{N}.xdmf"
 
 
 # Create mesh

--- a/src/KNPEMI/main.py
+++ b/src/KNPEMI/main.py
@@ -1,22 +1,39 @@
-from sys                 import argv
-from mpi4py              import MPI
-from KNPEMIx_solver      import SolverKNPEMI
-from KNPEMIx_problem     import ProblemKNPEMI
+import argparse
+from pathlib import Path
+
 from KNPEMIx_ionic_model import *
+from KNPEMIx_problem import ProblemKNPEMI
+from KNPEMIx_solver import SolverKNPEMI
+from parsers import CustomParser
+
+
+def main(argv=None):
+	parser = argparse.ArgumentParser(formatter_class=CustomParser)
+	parser.add_argument("-i", "--intra" ,default=1, type=int, help="Intracellular tag")
+	parser.add_argument("-e", "--extra" ,default=2, type=int, help="Extracellular tag")
+	parser.add_argument("-b", "--boundary" ,default=3, type=int, help="Boundary tag")
+	parser.add_argument("-m", "--membrane" ,default=4, type=int, help="Membrane tag")
+	parser.add_argument("--dt", default=5e-5, type=float, help="Time step")
+	parser.add_argument("--time_steps", default=50, type=int, help="Number of time steps")
+	parser.add_argument("--input", dest="input_file", default='geometries/square.xdmf', type=Path, help="Input file")
+	args = parser.parse_args(argv)
+	tags = {'intra' : args.intra, 'extra' : args.extra, 'boundary' : args.boundary, 'membrane' : args.membrane}
+
+	# Create problem
+	problem = ProblemKNPEMI(args.input_file, tags, args.dt)
+	# Set ionic models
+	HH = HH_model(problem)
+	ionic_models = [HH]
+
+	problem.init_ionic_model(ionic_models)
+
+	# Create solver and solve
+	solver = SolverKNPEMI(problem, args.time_steps)
+	solver.solve()
 
 if __name__=='__main__':
 
-	comm = MPI.COMM_WORLD # MPI communicator
-	
-	# global time step (s) and number of timesteps
-	dt = 5e-5
-	time_steps = 50
-
-	# square
-	N = int(argv[1]) # Number of mesh cells
-	input_file = f'geometries/square{N}.xdmf'	
-	tags = {'intra' : 1, 'extra' : 2, 'boundary' : 3, 'membrane' : 4}
-
+	main()
 	# # astrocyte
 	# input_file = 'geometries/astrocyte_mesh_full.xdmf'
 	# tags = {'intra' : 3, 'extra' : 1, 'boundary' : 4, 'membrane' : 5}
@@ -28,15 +45,4 @@ if __name__=='__main__':
 	# GC
 	# input_file = '../../../data/GC/'
 
-	# Create problem
-	problem = ProblemKNPEMI(input_file, tags, dt)
 
-	# Set ionic models
-	HH = HH_model(problem)
-	ionic_models = [HH]
-
-	problem.init_ionic_model(ionic_models)
-
-	# Create solver and solve
-	solver = SolverKNPEMI(problem, time_steps)
-	solver.solve()

--- a/src/KNPEMI/main.py
+++ b/src/KNPEMI/main.py
@@ -9,13 +9,15 @@ from parsers import CustomParser
 
 def main(argv=None):
 	parser = argparse.ArgumentParser(formatter_class=CustomParser)
-	parser.add_argument("-i", "--intra" ,default=1, type=int, help="Intracellular tag")
-	parser.add_argument("-e", "--extra" ,default=2, type=int, help="Extracellular tag")
-	parser.add_argument("-b", "--boundary" ,default=3, type=int, help="Boundary tag")
-	parser.add_argument("-m", "--membrane" ,default=4, type=int, help="Membrane tag")
-	parser.add_argument("--dt", default=5e-5, type=float, help="Time step")
-	parser.add_argument("--time_steps", default=50, type=int, help="Number of time steps")
 	parser.add_argument("--input", dest="input_file", default='geometries/square.xdmf', type=Path, help="Input file")
+	marker_opts = parser.add_argument_group("Domain markers", "Tags for the different domains")
+	marker_opts.add_argument("-i", "--intra" ,default=1, type=int, help="Intracellular tag")
+	marker_opts.add_argument("-e", "--extra" ,default=2, type=int, help="Extracellular tag")
+	marker_opts.add_argument("-b", "--boundary" ,default=3, type=int, help="Boundary tag")
+	marker_opts.add_argument("-m", "--membrane" ,default=4, type=int, help="Membrane tag")
+	temporal_opts = parser.add_argument_group("Temporal options", "Options for the temporal discretization")
+	temporal_opts.add_argument("--dt", default=5e-5, type=float, help="Time step")
+	temporal_opts.add_argument("--time_steps", default=50, type=int, help="Number of time steps")
 	args = parser.parse_args(argv)
 	tags = {'intra' : args.intra, 'extra' : args.extra, 'boundary' : args.boundary, 'membrane' : args.membrane}
 

--- a/src/KNPEMI/parsers.py
+++ b/src/KNPEMI/parsers.py
@@ -1,0 +1,5 @@
+import argparse
+
+class CustomParser(
+    argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
+): ...

--- a/src/KNPEMI/utils_dfx.py
+++ b/src/KNPEMI/utils_dfx.py
@@ -6,6 +6,7 @@ import collections.abc
 import numpy   as np
 import sympy   as sp
 import dolfinx as dfx
+import warnings
 
 from abc                      import ABC, abstractmethod
 from scipy                    import sparse
@@ -669,9 +670,9 @@ def mark_boundaries_square(mesh: dfx.mesh.Mesh) -> dfx.mesh.MeshTags:
 
     right_facets = dfx.mesh.locate_entities(mesh, facet_dim, right)
     facet_marker[right_facets] = GAMMA
-
     facet_tags = dfx.mesh.meshtags(mesh, facet_dim, np.arange(num_facets, dtype = np.int32), facet_marker)
-
+    if len(facet_tags.find(GAMMA)) == 0:
+        warnings.warn("No facets are marked with {GAMMA}")
     return facet_tags
 
 def mark_boundaries_square_MMS(mesh: dfx.mesh.Mesh) -> dfx.mesh.MeshTags:

--- a/src/KNPEMI/utils_dfx.py
+++ b/src/KNPEMI/utils_dfx.py
@@ -672,7 +672,7 @@ def mark_boundaries_square(mesh: dfx.mesh.Mesh) -> dfx.mesh.MeshTags:
     facet_marker[right_facets] = GAMMA
     facet_tags = dfx.mesh.meshtags(mesh, facet_dim, np.arange(num_facets, dtype = np.int32), facet_marker)
     if len(facet_tags.find(GAMMA)) == 0:
-        warnings.warn("No facets are marked with {GAMMA}")
+        warnings.warn(f"No facets are marked with {GAMMA}")
     return facet_tags
 
 def mark_boundaries_square_MMS(mesh: dfx.mesh.Mesh) -> dfx.mesh.MeshTags:


### PR DESCRIPTION
Runnable with:
```bash
python3 generate_square_mesh.py -N 20
python3 main.py --input=./geometries/square20.xdmf 
```
with support messages
```bash
python3 generate_square_mesh.py -h
usage: generate_square_mesh.py [-h] [-N N] [-f {r,w}] [-o OUTPUT_DIR]

Create a unit square mesh where a sub-square [0.25,0.25]x[0.75,0.75] is tagged as subdomain 1 and the rest as subdomain 2.
The exterior boundary as tagged as 3, the interface between the domains with 4 and all other facets with 5.

options:
  -h, --help            show this help message and exit
  -N N, --N N           Number of elements in each direction (default: 20)
  -f {r,w}, --flag {r,w}
                        Read or write (default: w)
  -o OUTPUT_DIR, --output OUTPUT_DIR
                        Output directory (default: ./geometries)
```
and
```bash
 python3 main.py -h
usage: main.py [-h] [--input INPUT_FILE] [-i INTRA] [-e EXTRA] [-b BOUNDARY] [-m MEMBRANE] [--dt DT] [--time_steps TIME_STEPS]

options:
  -h, --help            show this help message and exit
  --input INPUT_FILE    Input file (default: geometries/square.xdmf)

Domain markers:
  Tags for the different domains

  -i INTRA, --intra INTRA
                        Intracellular tag (default: 1)
  -e EXTRA, --extra EXTRA
                        Extracellular tag (default: 2)
  -b BOUNDARY, --boundary BOUNDARY
                        Boundary tag (default: 3)
  -m MEMBRANE, --membrane MEMBRANE
                        Membrane tag (default: 4)

Temporal options:
  Options for the temporal discretization

  --dt DT               Time step (default: 5e-05)
  --time_steps TIME_STEPS
                        Number of time steps (default: 50)
```