### PR TITLE
restructure XDMFs for ParaView visualization

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,8 +12,10 @@ dependencies:
   - git
   - mpich
   - conda-ecosystem-user-package-isolation
+  - pip
   - pip:
       - "multiphenicsx@git+https://github.com/multiphenics/multiphenicsx.git@dolfinx-v0.7.1"
       - pyyaml
+      - lxml
 
 

--- a/src/CGx/KNPEMI/KNPEMIx_solver.py
+++ b/src/CGx/KNPEMI/KNPEMIx_solver.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 
 from mpi4py         import MPI
 from petsc4py       import PETSc
+from CGx.utils      import restructure_xdmf
 from CGx.utils.misc import dump
 from CGx.KNPEMI.KNPEMIx_problem import ProblemKNPEMI
 
@@ -517,6 +518,7 @@ class SolverKNPEMI(object):
         filename = self.out_file_prefix + 'solution.xdmf'
         self.xdmf_file = dfx.io.XDMFFile(self.comm, filename, "w")
         self.xdmf_file.write_mesh(p.mesh)
+        self.output_filename = filename # Store the output filename for post-processing
 
         # Write solution functions to file
         for idx in range(p.N_ions+1):
@@ -537,7 +539,11 @@ class SolverKNPEMI(object):
     def close_xdmf(self):
         """ Close .xdmf files. """
 
+        # Close the XDMF file
         self.xdmf_file.close()
+        
+        # Run XDMF parser to restructure the data for better visualization
+        restructure_xdmf.run(self.output_filename)
 
         return
     

--- a/src/CGx/KNPEMI/config.yaml
+++ b/src/CGx/KNPEMI/config.yaml
@@ -2,7 +2,7 @@
 problem_type : "KNP-EMI"
 
 # Input and output directories
-output_dir : './output'
+output_dir : './output/'
 
 # Numerical parameters 
 dt : 0.00005 # Timestep size 

--- a/src/CGx/KNPEMI/main.py
+++ b/src/CGx/KNPEMI/main.py
@@ -66,7 +66,7 @@ def main_yaml(yaml_file="config.yaml"):
 	problem.init_ionic_model(ionic_models)
 
 	# Create solver and solve
-	solver = SolverKNPEMI(problem)
+	solver = SolverKNPEMI(problem, save_xdmfs=True)
 	solver.solve()
 
 	tags = {'intra' : 1, 'extra' : 2, 'boundary' : 3, 'membrane' : 4}

--- a/src/CGx/utils/generate_square_mesh.py
+++ b/src/CGx/utils/generate_square_mesh.py
@@ -1,11 +1,13 @@
 import os
 import argparse
+
 import dolfinx as dfx
 
 from mpi4py  import MPI
 from pathlib import Path
-from CGx.utils.misc     import mark_subdomains_square, mark_boundaries_square
+from CGx.utils.misc    import mark_subdomains_square, mark_boundaries_square
 from CGx.utils.parsers import CustomParser
+
 description = """
 Create a unit square mesh where a sub-square [0.25,0.25]x[0.75,0.75] is tagged as subdomain 1 and the rest as subdomain 2.
 The exterior boundary as tagged as 3, the interface between the domains with 4 and all other facets with 5.
@@ -13,15 +15,14 @@ The exterior boundary as tagged as 3, the interface between the domains with 4 a
 parser = argparse.ArgumentParser(formatter_class=CustomParser,
                                  description=description)
 parser.add_argument("-N", "--N" ,default=32, type=int, help="Number of elements in each direction")
-parser.add_argument("-f", "--flag", dest="flag", default='w', type=str, choices=["r", "w"], help="Read or write")
 parser.add_argument("-o", "--output", dest="output_dir", default='./geometries', type=Path, help="Output directory")
 args = parser.parse_args()
-flag = args.flag
 N = args.N
 gm = dfx.mesh.GhostMode.shared_facet
 comm = MPI.COMM_WORLD
 if not os.path.exists(args.output_dir): os.mkdir(args.output_dir)
-filename = args.output_dir / f"square{N}.xdmf"
+mesh_filename = args.output_dir / f"square{N}.xdmf"
+ft_filename   = args.output_dir / f"square{N}_facets.xdmf"
 
 # Create mesh
 mesh = dfx.mesh.create_unit_square(comm, nx=N, ny=N, ghost_mode=gm)
@@ -33,15 +34,8 @@ ct.name = "ct"
 ft = mark_boundaries_square(mesh)
 ft.name = "ft"
 
-if flag == 'w':
-    with dfx.io.XDMFFile(comm, filename, flag) as xdmf:
-        xdmf.write_mesh(mesh)
-        xdmf.write_meshtags(ct, x=mesh.geometry)
-        xdmf.write_meshtags(ft, x=mesh.geometry)
-
-elif flag == 'r':
-    with dfx.io.XDMFFile(comm, filename, flag) as xdmf:
-        mesh = xdmf.read_mesh(name = "mesh")
-        ct   = xdmf.read_meshtags(mesh, name = "ct")
-        mesh.topology.create_connectivity(mesh.topology.dim-1, mesh.topology.dim)
-        ft = xdmf.read_meshtags(mesh, name = "ft")
+with dfx.io.XDMFFile(comm, mesh_filename, 'w') as mesh_xdmf, \
+     dfx.io.XDMFFile(comm, ft_filename, 'w') as ft_xdmf:
+    mesh_xdmf.write_mesh(mesh)
+    mesh_xdmf.write_meshtags(ct, x=mesh.geometry)
+    ft_xdmf.write_meshtags(ft, x=mesh.geometry)

--- a/src/CGx/utils/restructure_xdmf.py
+++ b/src/CGx/utils/restructure_xdmf.py
@@ -1,0 +1,63 @@
+from lxml        import etree
+from collections import defaultdict
+
+def run(filename):
+
+    # Parse the XDMF file with lxml
+    parser = etree.XMLParser(remove_blank_text=True)
+    tree = etree.parse(filename, parser)
+    root = tree.getroot()
+
+    # Define namespace and get the xi:include element that serves as a pointer to the mesh
+    ns = {'xi': 'https://www.w3.org/2001/XInclude'}
+    xi_include_element = root.xpath("//xi:include", namespaces=ns)
+    if xi_include_element: xi_include_element = xi_include_element[0]  # Use the first found xi:include element
+
+    # Extract the mesh Grid
+    mesh_grid = root.xpath("//Grid[@Name='mesh']")
+
+    # Extract and group Grid elements by Time value
+    time_groups = defaultdict(list)
+    for collection_grid in root.xpath("//Grid[@GridType='Collection']"):
+        grids = collection_grid.xpath(".//Grid[@GridType='Uniform']")
+
+        # Group Grid elements by Time value
+        for grid in grids:
+            time_value = grid.find("Time").attrib['Value']
+            time_groups[time_value].append(grid)
+
+    # Create new Grid elements with grouped Time values
+    new_collection_grids = []
+    for time_value, grids in time_groups.items():
+        # Create a new Grid element
+        new_grid = etree.Element("Grid", Name=f"merged_time_{time_value}", GridType="Uniform")
+
+        # Add xi:include element. Use a deep copy to avoid reusing the same element
+        new_grid.append(etree.Element("{https://www.w3.org/2001/XInclude}include", attrib=xi_include_element.attrib))
+
+        # Add Time element
+        time_element = etree.Element("Time", Value=time_value)
+        new_grid.append(time_element)
+
+        # Add all Attributes from the grids in this group
+        for grid in grids:
+            for attribute in grid.findall("Attribute"):
+                new_grid.append(attribute)
+
+        # Create a new Collection Grid and add the merged Grid to it
+        new_collection_grid = etree.Element("Grid", Name=f"Collection_{time_value}", GridType="Collection", CollectionType="Temporal")
+        new_collection_grid.append(new_grid)
+        new_collection_grids.append(new_collection_grid)
+
+    # Clear original collection grids and append the new ones
+    root.clear()
+    root.append(etree.Element("Domain"))
+    for child in root:
+        child.append(mesh_grid[0])
+        for new_collection_grid in new_collection_grids:
+            child.append(new_collection_grid)
+
+    # Write the modified XDMF back to file
+    with open(filename, 'wb') as f:
+        tree.xpath("//Xdmf")[0].set("Version", "3.0") # Add version to XDMF header
+        f.write(etree.tostring(tree, pretty_print=True, xml_declaration=True, encoding='UTF-8'))


### PR DESCRIPTION
XDMF output files are restructured so that solution functions are grouped by timesteps, allowing for visualization in ParaView where the mesh is thresholded on the cell tags and all the functions can be used for coloring the mesh.